### PR TITLE
Denied access to log.txt Now it is only for administrators in control panel

### DIFF
--- a/upload/.htaccess
+++ b/upload/.htaccess
@@ -5,6 +5,10 @@ Options -Indexes
 
 php_flag register_globals off
 
+<Files log.txt>
+Deny from all 
+</Files>
+
 <IfModule mod_rewrite.c>
 SetEnv HTTP_MOD_REWRITE On
 


### PR DESCRIPTION
In log.txt can be logins and passwords.
