### PR TITLE
fixed Methods with the same name as their class will not be constructors in a future version error

### DIFF
--- a/upload/instruments/base.class.php
+++ b/upload/instruments/base.class.php
@@ -12,7 +12,7 @@ class Item extends View {
 
     public function __construct($id, $type, $db, $style_sd = false)
     {
-        parent::View($style_sd);
+        parent::__construct($style_sd);
 
         $this->id = (int) $id;
         $this->db = $db;
@@ -99,7 +99,7 @@ class View {
 
     protected $st_subdir;
 
-    public function View($style_subdir = '')
+    public function __construct($style_subdir = '')
     {
         if (!$style_subdir)
             $style_subdir = false;
@@ -460,7 +460,7 @@ class ItemLike
     private $bd_content;
     private $db;
 
-    public function ItemLike($item_type, $item_id, $user_id)
+    public function __construct($item_type, $item_id, $user_id)
     {
         global $bd_names;
 
@@ -531,11 +531,11 @@ class Menu extends View
     private $menu_items;
     private $menu_fname;
 
-    public function Menu($style_sd = false, $auto_load = true, $mfile = 'instruments/menu_items.php')
+    public function __construct($style_sd = false, $auto_load = true, $mfile = 'instruments/menu_items.php')
     {
         global $config;
 
-        parent::View($style_sd);
+        parent::__construct($style_sd);
 
         $this->menu_fname = $mfile;
 

--- a/upload/instruments/catalog.class.php
+++ b/upload/instruments/catalog.class.php
@@ -8,7 +8,7 @@ class Category
     private $name;
     private $priority;
 
-    public function Category($id = false)
+    public function __construct($id = false)
     {
         global $bd_names;
 
@@ -534,9 +534,9 @@ class NewsManager extends View
     private $work_link;
     private $category_id;
 
-    public function NewsManager($category = 1, $style_sd = false, $work_link = 'index.php?')
+    public function __construct($category = 1, $style_sd = false, $work_link = 'index.php?')
     { // category = -1 -- all last news
-        parent::View($style_sd);
+        parent::__construct($style_sd);
 
         if ((int) $category <= 0)
             $category = 0;

--- a/upload/instruments/monitoring.class.php
+++ b/upload/instruments/monitoring.class.php
@@ -17,7 +17,7 @@ class Server extends Item
     private $rcon;
     private $s_user;
 
-    public function Server($id = false, $style_sd = false)
+    public function __construct($id = false, $style_sd = false)
     {
         global $bd_names;
 
@@ -550,7 +550,7 @@ Class ServerManager extends View
     {
         global $site_ways;
 
-        parent::View($style_sd);
+        parent::__construct($style_sd);
     }
 
     public function Show($type = 'side', $update = false)

--- a/upload/instruments/upload.class.php
+++ b/upload/instruments/upload.class.php
@@ -34,11 +34,11 @@ Class File extends View
     private $hash;
     private $downloads;
 
-    public function File($id = false, $style_sd = false)
+    public function __construct($id = false, $style_sd = false)
     {
         global $bd_names;
 
-        parent::View($style_sd);
+        parent::__construct($style_sd);
 
         $this->base_dir = MCRAFT . 'userdata/';
         $this->db = $bd_names['files'];
@@ -310,7 +310,7 @@ Class FileManager extends View
     private $work_skript;
     private $db;
 
-    public function FileManager($style_sd = false, $work_skript = 'index.php?mode=control&do=filelist&')
+    public function __construct($style_sd = false, $work_skript = 'index.php?mode=control&do=filelist&')
     {
         global $bd_names;
 

--- a/upload/instruments/user.class.php
+++ b/upload/instruments/user.class.php
@@ -964,7 +964,7 @@ class Group extends TextBase
     private $db;
     private $id;
 
-    public function Group($id = false)
+    public function __construct($id = false)
     {
         global $bd_names;
 


### PR DESCRIPTION
changed methods names to __construct where methods had the same name as their class